### PR TITLE
Enhance quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Check out [wikiblocks-search](https://github.com/bmershon/wikiblocks-search) for
 
 # Quickstart
 
-To install the extension, download the *extension.crx* file and drag it into an open *chrome://extensions* window.
+To install the extension, download the *[extension.crx]([extension.crx](https://github.com/bmershon/wikiblocks-chrome/raw/master/extension.crx))* file and drag it into an open *chrome://extensions* window (navigate in the Chrome menu to Settings -> Extensions).
 
 *Navigate to a [Wikipedia page](https://en.wikipedia.org/wiki/Adjacency_matrix) and click on the page action icon.*
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Check out [wikiblocks-search](https://github.com/bmershon/wikiblocks-search) for
 
 # Quickstart
 
-To install the extension, download the *[extension.crx]([extension.crx](https://github.com/bmershon/wikiblocks-chrome/raw/master/extension.crx))* file and drag it into an open *chrome://extensions* window (navigate in the Chrome menu to Settings -> Extensions).
+To install the extension, download the *[extension.crx](https://github.com/bmershon/wikiblocks-chrome/raw/master/extension.crx)* file and drag it into an open *chrome://extensions* window (navigate in the Chrome menu to Settings -> Extensions).
 
 *Navigate to a [Wikipedia page](https://en.wikipedia.org/wiki/Adjacency_matrix) and click on the page action icon.*
 


### PR DESCRIPTION
This adds a link to the Chrome extension file in the quickstart, so people don't need to struggle to figure out how to download it. This also adds instructions on how to get to "chrome://extensions/". Unfortunately GitHub does not allow linking to "chrome://extensions/".

This is very exciting work, looking forward to see where it goes!
